### PR TITLE
package.json: use “repository” instead of “repositories”

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,10 @@
     "server"
   ],
   "url": "http://github.com/rubenv/node-autoquit",
-  "repositories": [
-    {
-      "type": "git",
-      "url": "git://github.com/rubenv/node-autoquit.git"
-    }
-  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/rubenv/node-autoquit.git"
+  },
   "author": "Ruben Vermeersch <ruben@savanne.be>",
   "contributors": [],
   "licenses": [


### PR DESCRIPTION
This commit fixes the following warning in projects depending on this
one:

```
npm WARN package.json autoquit@0.1.4 'repositories' (plural) Not supported.
npm WARN package.json Please pick one as the 'repository' field
```
