### PR TITLE
Fix process never quitting

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,8 @@ module.exports = function (grunt) {
         jshint: {
             all: ["lib/*.js", "test/*.js", "Gruntfile.js"],
             options: {
-                jshintrc: ".jshintrc"
+                jshintrc: ".jshintrc",
+                reporterOutput: "",
             }
         },
         watch: {

--- a/lib/autoquit.js
+++ b/lib/autoquit.js
@@ -31,19 +31,24 @@ Server.prototype.autoQuit = function (options) {
 
     var shutdownIfNeeded = function () {
         aquit.timeOutHandler = null;
-        if (aquit.connections > 0) {
-            // Still have connections!
-            return;
-        }
+        self.getConnections(function (err, count) {
+            if (!err && count > 0) {
+                // Still have connections!
+                aquit.lastActive = new Date().getTime();
+            }
 
-        var closeAt = aquit.lastActive + aquit.options.timeOut * 1000;
-        if (closeAt > new Date().getTime()) {
-            // Reschedule when we actually need to shut down.
-            aquit.timeOutHandler = setTimeout(shutdownIfNeeded, closeAt - new Date().getTime());
-            return;
-        }
-
-        shutdown();
+            var closeAt = aquit.lastActive + aquit.options.timeOut * 1000;
+            var now = new Date().getTime();
+            // Allow some tolerance as setTimeout callbacks are not precise
+            if (closeAt > now + 100) {
+                // Reschedule when we actually need to shut down.
+                if (aquit.timeOutHandler === null) {
+                    aquit.timeOutHandler = setTimeout(shutdownIfNeeded, closeAt - now);
+                }
+                return;
+            }
+            shutdown();
+        });
     };
 
     var isInactive = function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoquit",
-  "version": "0.1.7-rc.2",
+  "version": "0.1.6",
   "main": "./lib/autoquit.js",
   "description": "Automatically shut down servers when inactive",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoquit",
-  "version": "0.1.6",
+  "version": "0.1.7-rc.2",
   "main": "./lib/autoquit.js",
   "description": "Automatically shut down servers when inactive",
   "keywords": [

--- a/test/autoquit_test.js
+++ b/test/autoquit_test.js
@@ -58,7 +58,12 @@ function assertExits(cb) {
 }
 
 function pokeServer(cb) {
-    http.get('http://localhost:' + port, function (res) {
+    var options = {
+        hostname: 'localhost',
+        port: port,
+        agent: false
+    };
+    http.get(options, function (res) {
         assert.equal(res.statusCode, 200);
         cb();
     });


### PR DESCRIPTION
There were a couple of issues I was having:

1.  Intermittently, the connection counter remained above zero even after all connections had finished, even though `listen` was called after `autoquit`.  Debugging shows this was happening at a time when tens of connections where being made per second.  Some of the connections never fired the `end` event.  The behaviour appeared random.  I wonder whether it is sometimes possible that the connection end event occurs before the listener was registered in `countConnection`.

2.  The application would shutdown even though an active websocket was open.  Opening the websocket didn't fire the `request` event, so the application didn't see it as open.

Using the Net.getConnections() callback has proven to be reliable.  It also reports the websocket connection for which the event handlers don't get called.

Many thanks for a very useful application.
